### PR TITLE
returns directory of script

### DIFF
--- a/osintS34rCh.py
+++ b/osintS34rCh.py
@@ -112,7 +112,7 @@ def apiFile():
 	global censys_api_secret
 	global towerdata_api_key
 
-	pwd = os.path.dirname(sys.argv[0])
+	pwd = os.path.dirname(os.path.realpath(__file__))
 	filename = pwd + '/osintSearch.config.ini'
 
 	config = configparser.ConfigParser()


### PR DESCRIPTION
Current code returns "filename" as "/osintSearch.config.ini". Write fails because it tries to write to root directory. 

PR fixes this and writes "osintSearch.config.ini" to same directory as the script running.